### PR TITLE
Add check for invalid JSON parsing to avoid a segfault later on

### DIFF
--- a/src/doom/api.c
+++ b/src/doom/api.c
@@ -148,6 +148,11 @@ api_response_t API_RouteRequest(api_request_t req)
     char *path = req.url.path;
     cJSON *json = cJSON_Parse(req.body);
     
+    if (json == NULL)
+    {
+        return API_CreateErrorResponse(400, "Request body was not valid json.");
+    }
+
     if (strcmp(path, "api/message") == 0)
     {
         if (strcmp(method, "POST") == 0)


### PR DESCRIPTION
Without this change, sending an invalid json payload in a request will cause `cJSON_Parse(req.body);` to return null, and later calls made to `cJSON_GetObjectItem` will cause a segfault:

Emulating the behavior of the 'Doom 1.8' executable.
HU_Init: Setting up heads up display.
ST_Init: Init status bar.
API_Init: Init RESTful API daemon.
API_Init: Listening for connections on 0.0.0.0:6666
Segmentation fault: 11

With this change, you just get back a '400 bad request' response:

` 
a = requests.post('http://localhost:6666/api/player/actions', data = {'type' : 'shoot'})
a.text
u'{\n\t"error":\t"Request body was not valid json."\n}'
`