### PR TITLE
Fix json parsing segfault

### DIFF
--- a/src/doom/api.c
+++ b/src/doom/api.c
@@ -148,7 +148,7 @@ api_response_t API_RouteRequest(api_request_t req)
     char *path = req.url.path;
     cJSON *json = cJSON_Parse(req.body);
     
-    if (json == NULL)
+    if (strlen(req.body) > 0 && json == NULL)
     {
         return API_CreateErrorResponse(400, "Request body was not valid json.");
     }

--- a/src/doom/api.c
+++ b/src/doom/api.c
@@ -148,6 +148,11 @@ api_response_t API_RouteRequest(api_request_t req)
     char *path = req.url.path;
     cJSON *json = cJSON_Parse(req.body);
     
+    if (json == NULL)
+    {
+        return API_CreateErrorResponse(400, "Request body was not valid json.");
+    }
+
     if (strcmp(path, "api/message") == 0)
     {
         if (strcmp(method, "POST") == 0)


### PR DESCRIPTION
When an improperly formatted JSON payload is sent to the API, `cJSON_Parse(req.body);` will return NULL and the code will segfault later on when calling `cJSON_GetObjectItem`.

This fix checks if a body was sent, and returns an HTTP 400 response if it can't be parsed.