### PR TITLE
Fix compilation error and SDL sound buffer size

### DIFF
--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -402,6 +402,7 @@ static boolean ExpandSoundData_SRC(sfxinfo_t *sfxinfo,
                                    int length)
 {
     SRC_DATA src_data;
+    float *data_in;
     uint32_t i, abuf_index=0, clipped=0;
 //    uint32_t alen;
     int retn;
@@ -410,7 +411,8 @@ static boolean ExpandSoundData_SRC(sfxinfo_t *sfxinfo,
     Mix_Chunk *chunk;
 
     src_data.input_frames = length;
-    src_data.data_in = malloc(length * sizeof(float));
+    data_in = malloc(length * sizeof(float));
+    src_data.data_in = data_in;
     src_data.src_ratio = (double)mixer_freq / samplerate;
 
     // We include some extra space here in case of rounding-up.
@@ -426,7 +428,7 @@ static boolean ExpandSoundData_SRC(sfxinfo_t *sfxinfo,
         // Unclear whether 128 should be interpreted as "zero" or whether a
         // symmetrical range should be assumed.  The following assumes a
         // symmetrical range.
-        src_data.data_in[i] = data[i] / 127.5 - 1;
+        data_in[i] = data[i] / 127.5 - 1;
     }
 
     // Do the sound conversion
@@ -495,7 +497,7 @@ static boolean ExpandSoundData_SRC(sfxinfo_t *sfxinfo,
         expanded[abuf_index++] = cvtval_i;
     }
 
-    free(src_data.data_in);
+    free(data_in);
     free(src_data.data_out);
 
     if (clipped > 0)

--- a/src/i_sdlsound.c
+++ b/src/i_sdlsound.c
@@ -629,11 +629,15 @@ static boolean ExpandSoundData_SDL(sfxinfo_t *sfxinfo,
                           AUDIO_U8, 1, samplerate,
                           mixer_format, mixer_channels, mixer_freq))
     {
-        convertor.buf = chunk->abuf;
         convertor.len = length;
+        convertor.buf = malloc(convertor.len * convertor.len_mult);
+        assert(convertor.buf != NULL);
         memcpy(convertor.buf, data, length);
 
         SDL_ConvertAudio(&convertor);
+
+        memcpy(chunk->abuf, convertor.buf, chunk->alen);
+        free(convertor.buf);
     }
     else
     {


### PR DESCRIPTION
This PR is comprised of two fixes that I found which allowed me to build and run this successfully on Arch Linux with SDL 2.0.7. It fixes the following build error:

`i_sdlsound.c:429:29: error: assignment of read-only location`

...and allocates a large enough buffer for SDL_ConvertAudio, which resolves a segfault as soon as any digital sound is played. 

I realize that `restful-doom` appears to be behind `chocolate-doom`, however I'm hoping this may help others trying to quickly compile + run it under a similar setup. My skillset (or lack thereof) only got me this far, so feel free to reject this PR if I didn't do things correctly. The comments in both of the original commits (credit linked to in my commit msgs) explain more in detail.

Side point, now that I've got it running, `restful-doom` is a _very_ cool project/idea indeed!