### PR TITLE
"No Clip" flag should only have one underscore

### DIFF
--- a/RAML/cheat_flags.raml
+++ b/RAML/cheat_flags.raml
@@ -5,6 +5,6 @@ properties:
   CF_GODMODE:
     type: boolean
     required: false
-  CF_NO_CLIP:
+  CF_NOCLIP:
     type: boolean
     required: false


### PR DESCRIPTION
CF_NO_CLIP should be CF_NOCLIP, just like CF_GODMODE's format.

VOD showing this on stream via a curl request: https://clips.twitch.tv/TriangularBoldWebRedCoat